### PR TITLE
Moved emoteAnimator check

### DIFF
--- a/UMI3D-Browser-Desktop/Assets/Project/Scripts/IK Management/EmoteManager.cs
+++ b/UMI3D-Browser-Desktop/Assets/Project/Scripts/IK Management/EmoteManager.cs
@@ -135,9 +135,9 @@ namespace umi3dDesktopBrowser.emotes
             }
 
             var emoteFromBundleAnimator = avatar.GetComponentInChildren<Animator>();
-            emoteFromBundleAnimator.enabled = false; //disabled because it causes interferences with avatar bindings
             if (emoteFromBundleAnimator != null)
             {
+                emoteFromBundleAnimator.enabled = false; //disabled because it causes interferences with avatar bindings
                 if (emoteFromBundleAnimator.runtimeAnimatorController == null)
                 {
                     DisableEmoteSystem();


### PR DESCRIPTION
Fixed bug declared in card BUG 5726 where the GetEmote coroutine raises a nullref error instead of disabling the emote system in environments with no emote support