### PR TITLE
Fixed emote not interrupting correctly

### DIFF
--- a/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/Connections/BaseGamePanelController_Controls.cs
+++ b/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/Connections/BaseGamePanelController_Controls.cs
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 using umi3d.baseBrowser.cursor;
+using umi3d.baseBrowser.emotes;
 using umi3d.baseBrowser.inputs.interactions;
 using umi3d.commonScreen.game;
 using UnityEngine;
@@ -121,7 +122,7 @@ namespace umi3d.baseBrowser.connection
 
                 if (EmoteWindow_C.Emotes == null || EmoteWindow_C.Emotes.Count <= index) return;
                 var emote = EmoteWindow_C.Emotes[index];
-                emote.PlayEmote(emote);
+                EmoteManager.Instance.PlayEmote(emote);
             };
 
             BaseConnectionProcess.Instance.EnvironmentLeave += () => NotifAndUsersArea_C.Instance = null;

--- a/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/UI/Custom Controllers/GamePanel/Common Screen Game/EmoteWindow_C.cs
+++ b/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/UI/Custom Controllers/GamePanel/Common Screen Game/EmoteWindow_C.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using UnityEngine.UIElements;
 using umi3d.commonScreen.Displayer;
 using umi3d.commonScreen.Container;
+using umi3d.baseBrowser.emotes;
 
 namespace umi3d.commonScreen.game
 {
@@ -99,7 +100,7 @@ namespace umi3d.commonScreen.game
 
                 emoteButton.Body.RegisterCallback<GeometryChangedEvent>(evt => emoteButton.Body.style.width = emoteButton.layout.height);
 
-                emoteButton.clicked += () => emote.PlayEmote(emote);
+                emoteButton.clicked += () => EmoteManager.Instance.PlayEmote(emote);
             }
         }
 


### PR DESCRIPTION
Emotes were interrupted in an anormal way due to :
- Not stopping correctly the coroutine after playing
- Unable to exit the coroutine normally as animationStateMachine has delay and was not comparing values on the right state