### PR TITLE
Fix the typo on "Environment" displayed on all connections

### DIFF
--- a/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/Connections/BaseConnectionProcess.cs
+++ b/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/Connections/BaseConnectionProcess.cs
@@ -89,7 +89,7 @@ namespace umi3d.baseBrowser.connection
 
             cdk.collaboration.UMI3DCollaborationClientServer.EnvironmentProgress = () =>
             {
-                var p = new MultiProgress("Join Environement");
+                var p = new MultiProgress("Join Environment");
                 //p.ResumeAfterFail = ResumeAfterFail;
                 p.ResumeAfterFail = async (e) =>
                 {


### PR DESCRIPTION
Minor but always displayed.