### PR TITLE
Fix Y head rotation

### DIFF
--- a/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/Navigations/Camera/UMI3DCameraManager.cs
+++ b/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/Navigations/Camera/UMI3DCameraManager.cs
@@ -92,14 +92,14 @@ public sealed class UMI3DCameraManager
 
         Vector3 headAngle = new Vector3(
             Mathf.Clamp(viewpointXAxis, data.maxXHeadAngle.x, data.maxXHeadAngle.y),
-            viewpointYAxis,
+            viewpointYAxis / 2,
             0f
         );
         head.localRotation = Quaternion.Euler(headAngle);
 
         Vector3 neckAngle = new Vector3(
             Mathf.Clamp(viewpointXAxis, -data.maxNeckAngle, data.maxNeckAngle),
-            viewpointYAxis,
+            viewpointYAxis / 2,
             0f
         );
         neckPivot.localRotation = Quaternion.Euler(neckAngle);


### PR DESCRIPTION
Divided by two because applied by both neck and head as parent-child relation