### PR TITLE
Fix head rotation on X axis

### DIFF
--- a/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/Navigations/Camera/UMI3DCameraManager.cs
+++ b/UMI3D-Browser-Desktop/Assets/Dependencies/UMI3D Screen Browsers Base/Scripts/Navigations/Camera/UMI3DCameraManager.cs
@@ -94,14 +94,14 @@ public sealed class UMI3DCameraManager
         viewpointPivot.localRotation = Quaternion.Euler(viewpointXAxis, viewpointYAxis, 0f);
 
         Vector3 headAngle = new Vector3(
-            Mathf.Clamp(viewpointXAxis, data.maxXHeadAngle.x, data.maxXHeadAngle.y),
+            Mathf.Clamp(viewpointXAxis, data.maxXHeadAngle.x, data.maxXHeadAngle.y) / 2,
             viewpointYAxis / 2,
             0f
         );
         head.localRotation = Quaternion.Euler(headAngle);
 
         Vector3 neckAngle = new Vector3(
-            Mathf.Clamp(viewpointXAxis, -data.maxNeckAngle, data.maxNeckAngle),
+            Mathf.Clamp(viewpointXAxis, -data.maxNeckAngle, data.maxNeckAngle) / 2,
             viewpointYAxis / 2,
             0f
         );

--- a/UMI3D-Browser-Desktop/ProjectSettings/QualitySettings.asset
+++ b/UMI3D-Browser-Desktop/ProjectSettings/QualitySettings.asset
@@ -4,7 +4,7 @@
 QualitySettings:
   m_ObjectHideFlags: 0
   serializedVersion: 5
-  m_CurrentQuality: 5
+  m_CurrentQuality: 2
   m_QualitySettings:
   - serializedVersion: 3
     name: Very Low


### PR DESCRIPTION
The X rotation of the head was multiplied by two, making it possible to see behind the head, and creating weird behaviours when trying to do so.

Issue was thought to come from the new muscle system but came from the camera management on the neck + head pivots.